### PR TITLE
Add import of print_function and remove quit

### DIFF
--- a/gnome_screensaver_away.py
+++ b/gnome_screensaver_away.py
@@ -23,13 +23,14 @@
 # Contributions welcome at:
 # https://github.com/grdryn/weechat-gnome-screensaver-away
 
+from __future__ import print_function
+
 try:
     import dbus
     import weechat
 except ImportError:
     print('This program is intended to be run by weechat, and expects the')
     print('dbus-python library to be installed.')
-    quit()
 
 SCRIPT_NAME    = 'gnome-screensaver-away'
 SCRIPT_AUTHOR  = 'Gerard Ryan <gerard@ryan.lt>'


### PR DESCRIPTION
The quit() must not be used in any weechat script, because this would exit weechat itself.